### PR TITLE
Add chunk planner utilities and tests

### DIFF
--- a/chunk_planner.c
+++ b/chunk_planner.c
@@ -1,0 +1,69 @@
+#include "chunk_planner.h"
+
+static size_t elem_size(DATATYPE dt) {
+    switch (dt) {
+    case DT_INT32:
+        return sizeof(int32_t);
+    case DT_DOUBLE:
+        return sizeof(double);
+    default:
+        return 0;
+    }
+}
+
+size_t chunk_elems_from_bytes(size_t chunk_bytes, DATATYPE dt) {
+    size_t es = elem_size(dt);
+    if (es == 0) return 0;
+    size_t elems = chunk_bytes / es;
+    if (elems == 0) elems = 1;
+    return elems;
+}
+
+size_t chunk_count(size_t count, size_t chunk_elems) {
+    if (chunk_elems == 0) return 0;
+    return (count + chunk_elems - 1) / chunk_elems;
+}
+
+int rs_send_chunk_index(int round, int rank, int world_size) {
+    if (world_size <= 0) return -1;
+    int r = round % world_size;
+    int p = rank % world_size;
+    if (p < 0) p += world_size;
+    return (p - r + world_size) % world_size;
+}
+
+int rs_recv_chunk_index(int round, int rank, int world_size) {
+    if (world_size <= 0) return -1;
+    int r = round % world_size;
+    int p = rank % world_size;
+    if (p < 0) p += world_size;
+    return (p - r - 1 + world_size) % world_size;
+}
+
+static void chunk_offsets(size_t count, size_t chunk_elems, DATATYPE dt,
+                          size_t chunk_index, size_t *offset_bytes,
+                          size_t *len_bytes) {
+    size_t es = elem_size(dt);
+    size_t start_elem = chunk_index * chunk_elems;
+    if (start_elem >= count) {
+        *offset_bytes = 0;
+        *len_bytes = 0;
+        return;
+    }
+    size_t end_elem = start_elem + chunk_elems;
+    if (end_elem > count) end_elem = count;
+    *offset_bytes = start_elem * es;
+    *len_bytes = (end_elem - start_elem) * es;
+}
+
+void rs_chunk_offsets(size_t count, size_t chunk_elems, DATATYPE dt,
+                      size_t chunk_index, size_t *offset_bytes,
+                      size_t *len_bytes) {
+    chunk_offsets(count, chunk_elems, dt, chunk_index, offset_bytes, len_bytes);
+}
+
+void ag_chunk_offsets(size_t count, size_t chunk_elems, DATATYPE dt,
+                      size_t chunk_index, size_t *offset_bytes,
+                      size_t *len_bytes) {
+    chunk_offsets(count, chunk_elems, dt, chunk_index, offset_bytes, len_bytes);
+}

--- a/chunk_planner.h
+++ b/chunk_planner.h
@@ -1,0 +1,30 @@
+#ifndef CHUNK_PLANNER_H
+#define CHUNK_PLANNER_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "pg.h"  /* for DATATYPE */
+
+/* Convert chunk_bytes to element count for the given datatype. */
+size_t chunk_elems_from_bytes(size_t chunk_bytes, DATATYPE dt);
+
+/* Number of chunks needed to cover count elements with chunk_elems per chunk. */
+size_t chunk_count(size_t count, size_t chunk_elems);
+
+/* Reduce-scatter send chunk index for round r and rank p. Returns -1 if world_size <=0. */
+int rs_send_chunk_index(int round, int rank, int world_size);
+
+/* Reduce-scatter recv chunk index for round r and rank p. Returns -1 if world_size <=0. */
+int rs_recv_chunk_index(int round, int rank, int world_size);
+
+/* Compute byte offset and length for chunk index in reduce-scatter. */
+void rs_chunk_offsets(size_t count, size_t chunk_elems, DATATYPE dt,
+                      size_t chunk_index, size_t *offset_bytes,
+                      size_t *len_bytes);
+
+/* Compute byte offset and length for chunk index in all-gather. */
+void ag_chunk_offsets(size_t count, size_t chunk_elems, DATATYPE dt,
+                      size_t chunk_index, size_t *offset_bytes,
+                      size_t *len_bytes);
+
+#endif /* CHUNK_PLANNER_H */

--- a/chunk_planner_test.c
+++ b/chunk_planner_test.c
@@ -1,0 +1,58 @@
+#include "chunk_planner.h"
+#include <assert.h>
+#include <stdio.h>
+
+static void test_chunk_elems(void) {
+    assert(chunk_elems_from_bytes(32, DT_INT32) == 8);
+    assert(chunk_elems_from_bytes(40, DT_DOUBLE) == 5);
+}
+
+static void test_chunk_count(void) {
+    size_t elems = chunk_elems_from_bytes(16, DT_INT32); /* 4 */
+    assert(chunk_count(10, elems) == 3);
+    assert(chunk_count(8, elems) == 2);
+}
+
+static void test_rs_indices(void) {
+    int N = 4;
+    /* rank 0 */
+    assert(rs_send_chunk_index(0, 0, N) == 0);
+    assert(rs_recv_chunk_index(0, 0, N) == 3);
+    assert(rs_send_chunk_index(1, 0, N) == 3);
+    assert(rs_recv_chunk_index(1, 0, N) == 2);
+    assert(rs_send_chunk_index(2, 0, N) == 2);
+    assert(rs_recv_chunk_index(2, 0, N) == 1);
+    /* rank 2 */
+    assert(rs_send_chunk_index(0, 2, N) == 2);
+    assert(rs_recv_chunk_index(0, 2, N) == 1);
+    assert(rs_send_chunk_index(1, 2, N) == 1);
+    assert(rs_recv_chunk_index(1, 2, N) == 0);
+}
+
+static void check_offsets(size_t count, size_t last_bytes) {
+    size_t elems = chunk_elems_from_bytes(16, DT_INT32); /* 4 */
+    size_t off, len;
+    rs_chunk_offsets(count, elems, DT_INT32, 0, &off, &len);
+    assert(off == 0 && len == 16);
+    rs_chunk_offsets(count, elems, DT_INT32, 1, &off, &len);
+    assert(off == 16 && len == 16);
+    rs_chunk_offsets(count, elems, DT_INT32, 2, &off, &len);
+    assert(off == 32 && len == last_bytes);
+    /* ag offsets mirror rs */
+    ag_chunk_offsets(count, elems, DT_INT32, 2, &off, &len);
+    assert(off == 32 && len == last_bytes);
+}
+
+static void test_offsets(void) {
+    check_offsets(10, 8); /* last chunk has 2 elements */
+    check_offsets(9, 4);  /* last chunk has 1 element */
+}
+
+int main(void) {
+    test_chunk_elems();
+    test_chunk_count();
+    test_rs_indices();
+    test_offsets();
+    printf("Chunk planner tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add chunk planner to compute chunk sizes, counts, rs/ag mappings
- include unit tests for uneven counts with N=4